### PR TITLE
fix: swap env parser from dotenv-safe to dotenv

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "typescript": "^4.9.4"
   },
   "dependencies": {
-    "dotenv-safe": "^8.2.0",
+    "dotenv": "^16.0.3",
     "express": "^4.18.2",
     "jasmine": "^4.5.0",
     "jasmine-spec-reporter": "^7.0.0",

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -1,5 +1,5 @@
 import { ServerConfig } from './env.types'
-import dotenv from 'dotenv-safe'
+import dotenv from 'dotenv'
 
 type Env = {
   Server: ServerConfig

--- a/yarn.lock
+++ b/yarn.lock
@@ -885,12 +885,10 @@ doctrine@^3.0.0:
   dependencies:
     esutils "^2.0.2"
 
-dotenv-safe@^8.2.0:
-  version "8.2.0"
-  resolved "https://registry.yarnpkg.com/dotenv-safe/-/dotenv-safe-8.2.0.tgz#8d548c7318a62c09a66c4dc8c31864cc007c78ba"
-  integrity sha512-uWwWWdUQkSs5a3mySDB22UtNwyEYi0JtEQu+vDzIqr9OjbDdC2Ip13PnSpi/fctqlYmzkxCeabiyCAOROuAIaA==
-  dependencies:
-    dotenv "^8.2.0"
+dotenv@^16.0.3:
+  version "16.0.3"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.0.3.tgz#115aec42bac5053db3c456db30cc243a5a836a07"
+  integrity sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==
 
 dotenv@^8.2.0:
   version "8.6.0"


### PR DESCRIPTION
### What does this PR do?
 - Swap env parser to remove dotenv-safe and utilize dotenv instead.
### How should this be manually tested?
 - Build and run the project.